### PR TITLE
move Ferraris meter code into objects

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -80,7 +80,8 @@
     {
         "name": "meter_counter_reading_1",
         "label": "Zählerstand [kWh]",
-        "type": "uint32_t",
+        "type": "float",
+        "digits": 1,
         "value": "0"
     },
     {
@@ -102,7 +103,8 @@
     {
         "name": "meter_counter_reading_2",
         "label": "Zählerstand [kWh]",
-        "type": "uint32_t",
+        "type": "float",
+        "digits": 1,
         "value": "0"
     },
     {
@@ -124,7 +126,8 @@
     {
         "name": "meter_counter_reading_3",
         "label": "Zählerstand [kWh]",
-        "type": "uint32_t",
+        "type": "float",
+        "digits": 1,
         "value": "0"
     },
     {
@@ -146,7 +149,8 @@
     {
         "name": "meter_counter_reading_4",
         "label": "Zählerstand [kWh]",
-        "type": "uint32_t",
+        "type": "float",
+        "digits": 1,
         "value": "0"
     },
     {

--- a/dashboard.json
+++ b/dashboard.json
@@ -65,14 +65,14 @@
     {
         "name": "revolutions_1",
         "label": "Umdrehungen [U]",
-        "type": "int16_t",
+        "type": "uint32_t",
         "length": 5,
         "direction": "display"
     },
     {
-        "name": "kW_1",
-        "label": "Leistung [kW]",
-        "type": "float",
+        "name": "W_1",
+        "label": "Leistung [W]",
+        "type": "uint16_t",
         "digits": 3,
         "direction": "display"
     },
@@ -90,14 +90,14 @@
     {
         "name": "revolutions_2",
         "label": "Umdrehungen [U]",
-        "type": "int16_t",
+        "type": "uint32_t",
         "length": 5,
         "direction": "display"
     },
     {
-        "name": "kW_2",
-        "label": "Leistung [kW]",
-        "type": "float",
+        "name": "W_2",
+        "label": "Leistung [W]",
+        "type": "uint16_t",
         "digits": 3,
         "direction": "display"
     },
@@ -115,14 +115,14 @@
     {
         "name": "revolutions_3",
         "label": "Umdrehungen [U]",
-        "type": "int16_t",
+        "type": "uint32_t",
         "length": 5,
         "direction": "display"
     },
     {
-        "name": "kW_3",
-        "label": "Leistung [kW]",
-        "type": "float",
+        "name": "W_3",
+        "label": "Leistung [W]",
+        "type": "uint16_t",
         "digits": 3,
         "direction": "display"
     },
@@ -140,14 +140,14 @@
     {
         "name": "revolutions_4",
         "label": "Umdrehungen [U]",
-        "type": "int16_t",
+        "type": "uint32_t",
         "length": 5,
         "direction": "display"
     },
     {
-        "name": "kW_4",
-        "label": "Leistung [kW]",
-        "type": "float",
+        "name": "W_4",
+        "label": "Leistung [W]",
+        "type": "uint16_t",
         "digits": 3,
         "direction": "display"
     },

--- a/src/ferraris.cpp
+++ b/src/ferraris.cpp
@@ -1,0 +1,229 @@
+#include "ferraris.h"
+#include <Arduino.h>
+
+
+// ugly stuff to get interrupt callable
+static void IRAM_ATTR staticInterruptHandler0() { Ferraris::getInstance(0).IRQhandler(); }
+static void IRAM_ATTR staticInterruptHandler1() { Ferraris::getInstance(1).IRQhandler(); }
+static void IRAM_ATTR staticInterruptHandler2() { Ferraris::getInstance(2).IRQhandler(); }
+static void IRAM_ATTR staticInterruptHandler3() { Ferraris::getInstance(3).IRQhandler(); }
+static void IRAM_ATTR staticInterruptHandler4() { Ferraris::getInstance(4).IRQhandler(); }
+static void IRAM_ATTR staticInterruptHandler5() { Ferraris::getInstance(5).IRQhandler(); }
+static void IRAM_ATTR staticInterruptHandler6() { Ferraris::getInstance(6).IRQhandler(); }
+
+void (*staticInterruptHandlers[FERRARIS_NUM])() =
+{
+  &staticInterruptHandler0,
+#if FERRARIS_NUM > 1
+  &staticInterruptHandler1,
+#endif
+#if FERRARIS_NUM > 2
+  &staticInterruptHandler2,
+#endif
+#if FERRARIS_NUM > 3
+  &staticInterruptHandler3,
+#endif
+#if FERRARIS_NUM > 4
+  &staticInterruptHandler4,
+#endif
+#if FERRARIS_NUM > 5
+  &staticInterruptHandler5,
+#endif
+#if FERRARIS_NUM > 6
+  &staticInterruptHandler6
+#endif
+};
+
+
+// initialize private instance counter
+uint8_t Ferraris::FINSTANCE = 0;
+
+// private constructor
+Ferraris::Ferraris()
+  : m_state(startup)
+  , m_timestamp(millis())
+  , m_revolutions(0)
+  , m_rev_kWh(75)
+  , m_debounce(80)
+  , m_changed(false)
+{
+  uint8_t F = Ferraris::FINSTANCE++;
+  m_PIN = Ferraris::PINS[F];
+  pinMode(m_PIN, INPUT_PULLUP);
+  switch (F) {
+    case 0: m_handler = staticInterruptHandler0; break;
+    case 1: m_handler = staticInterruptHandler1; break;
+    case 2: m_handler = staticInterruptHandler2; break;
+    case 3: m_handler = staticInterruptHandler3; break;
+    case 4: m_handler = staticInterruptHandler4; break;
+    case 5: m_handler = staticInterruptHandler5; break;
+    case 6: m_handler = staticInterruptHandler6; break;
+    default: abort();
+  }
+}
+
+Ferraris& Ferraris::getInstance(unsigned char F)
+{
+  static Ferraris singleton[FERRARIS_NUM];
+  assert(F < FERRARIS_NUM);
+  return singleton[F];
+}
+
+
+// ----------------------------------------------------------------------------
+// main interface
+// ----------------------------------------------------------------------------
+
+void Ferraris::begin()
+{
+  u_int8_t value = digitalRead(m_PIN);
+
+  if (value == FERRARIS_SILVER) {
+    m_state = Ferraris::states::silver_debounce;
+  }
+
+  if (value == FERRARIS_RED) {
+    m_state = Ferraris::states::red_debounce;
+    m_timestampLast1 = m_timestamp;
+    m_timestampLast2 = m_timestamp;
+  }
+  m_changed = true;
+}
+
+// define IRQ mode to get to PIN state
+#if (FERRARIS_RED == HIGH)
+  #define FERRARIS_IRQMODE_RED     RISING
+  #define FERRARIS_IRQMODE_SILVER  FALLING
+#else
+  #define FERRARIS_IRQMODE_RED     FALLING
+  #define FERRARIS_IRQMODE_SILVER  RISING
+#endif
+
+bool Ferraris::loop()
+{
+  // wait for debounce time
+  int timestamp = millis();
+  if (m_state == Ferraris::states::silver_debounce)
+    if ((timestamp - m_timestamp) >= 4*m_debounce) {
+      m_state = Ferraris::states::silver;
+      detachInterrupt(digitalPinToInterrupt(m_PIN));
+      attachInterrupt(digitalPinToInterrupt(m_PIN), m_handler, FERRARIS_IRQMODE_RED);
+    }  
+
+  if (m_state == Ferraris::states::red_debounce)
+    if ((timestamp - m_timestamp) >= m_debounce) {
+      if (digitalRead(m_PIN) == FERRARIS_RED) {
+        m_state = Ferraris::states::red;
+        detachInterrupt(digitalPinToInterrupt(m_PIN));
+        attachInterrupt(digitalPinToInterrupt(m_PIN), m_handler, FERRARIS_IRQMODE_SILVER);
+      } else {
+        // we missed RED -> SILVER !
+        m_state = Ferraris::states::silver_debounce;
+        m_timestamp = timestamp;
+        Serial.println("Missed RED->SILVER !");
+      }
+    }  
+
+  // return "something has changed" state
+  bool retval = m_changed;
+  m_changed = false;
+  return retval;
+}
+
+void Ferraris::IRQhandler()
+{
+  // disable interrupt during debounce time
+  //detachInterrupt(digitalPinToInterrupt(m_PIN));
+  m_timestamp = millis();
+
+  // silver -> red
+  if (m_state == Ferraris::states::silver) {
+    m_state = Ferraris::states::red_debounce;
+    m_revolutions++;
+    m_timestampLast2 = m_timestampLast1;
+    m_timestampLast1 = m_timestamp;
+    m_changed = true;
+  }  
+
+  // red -> silver
+  if (m_state == Ferraris::states::red) {
+    m_state = Ferraris::states::silver_debounce;
+  }  
+}
+
+
+// ----------------------------------------------------------------------------
+// calculation functions
+// ----------------------------------------------------------------------------
+
+bool Ferraris::get_state() const
+{
+  switch (m_state) {
+    case Ferraris::states::silver:
+    case Ferraris::states::silver_debounce:
+      return FERRARIS_SILVER;
+      break;
+    default:
+      return FERRARIS_RED;
+  }
+}
+
+int Ferraris::get_W() const
+{
+  unsigned long elapsedtime = m_timestampLast1 - m_timestampLast2;  // last full cycle
+  if (elapsedtime == 0) return 0;
+  unsigned long runningtime = millis() - m_timestampLast1;          // current open cycle
+  // [60 min * 60 sec * 1000 ms] * [1 kW -> 1000 W] / [time for 1kWh]
+  return 3600000000 / (std::max(elapsedtime, runningtime) * m_rev_kWh);  
+}
+
+float Ferraris::get_kW() const
+{
+  unsigned long elapsedtime = m_timestampLast1 - m_timestampLast2;  // last full cycle
+  if (elapsedtime == 0) return 0.0f;
+  unsigned long runningtime = millis() - m_timestampLast1;          // current open cycle
+  // [60 min * 60 sec * 1000 ms] * [1 kW] / [time for 1kWh]
+  return 3600000.0f / (std::max(elapsedtime, runningtime) * m_rev_kWh);  
+}
+
+float Ferraris::get_kWh() const
+{
+  return float(m_revolutions) / float(m_rev_kWh);
+}
+
+
+// ----------------------------------------------------------------------------
+// simple getter and setter
+// ----------------------------------------------------------------------------
+
+unsigned long Ferraris::get_revolutions() const
+{
+  return m_revolutions;
+}
+
+void Ferraris::set_revolutions(unsigned long value)
+{
+  m_revolutions = value;
+  m_changed = true;
+}
+
+unsigned int Ferraris::get_U_kWh() const
+{
+  return m_rev_kWh;
+}
+
+void Ferraris::set_U_kWh(unsigned int value)
+{
+  m_rev_kWh = value;
+  m_changed = true;
+}
+
+unsigned int Ferraris::get_debounce() const
+{
+  return m_debounce;
+}
+
+void Ferraris::set_debounce(unsigned int value)
+{
+  m_debounce = value;
+}

--- a/src/ferraris.h
+++ b/src/ferraris.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <Arduino.h>
+
+
+// how many Ferraris meters do we want
+#define FERRARIS_NUM 4
+
+// define logic level of pin input
+#define FERRARIS_RED     HIGH
+#define FERRARIS_SILVER  LOW
+
+
+class Ferraris {
+  public:
+  /*
+  * Used pins          NodeMCU V2+V3   Wemos D1    Wemos D1 mini
+  * Internal LED       <D0> GPIO 16    (IO16)      (D0)
+  * IR Pin Messure 1   (D1) GPIO 05    (IO5)       (D1)
+  * IR Pin Messure 2   (D2) GPIO 04    (IO4)       (D2)
+  * IR Pin Messure 3   (D3) GPIO 00    (IO0)       (D3)
+  * ESP8266 LED        <D4> GPIO 02    <IO2>       <D4>
+  * IR Pin Messure 4   (D5) GPIO 14    (IO14)      (D5)
+  * IR Pin Messure 5   (D6) GPIO 12    (IO12)      (D6)
+  * IR Pin Messure 6   (D7) GPIO 13    (IO13)      (D7)
+  * IR Pin Messure 7   (D8) GPIO 15                (D8)
+  */
+    const u_int8_t PINS[7] = {D1, D2, D3, D5, D6, D7, D8};
+
+  private: // singleton pattern: prevent access to constructors
+    Ferraris();
+    Ferraris(const Ferraris &);
+    Ferraris &operator=(const Ferraris &);
+
+  public:
+    static Ferraris& getInstance(unsigned char F);
+    
+    void            begin();
+    bool            loop();
+
+    void            IRQhandler();
+
+    bool            get_state() const;  // current PIN state
+    int             get_W() const;      // current consumption in W
+    float           get_kW() const;     // current consumption in kW
+    float           get_kWh() const;    // total reading of meter
+
+    // total revolution count
+    unsigned long   get_revolutions() const;
+    void            set_revolutions(unsigned long value);
+
+    // config: revolutions per kWh
+    unsigned int    get_U_kWh() const;
+    void            set_U_kWh(unsigned int value);
+
+    // config: debounce time [ms]
+    unsigned int    get_debounce() const;
+    void            set_debounce(unsigned int value);
+
+    enum states {startup, silver_debounce, silver, red_debounce, red};
+
+  private:
+    uint8_t           m_PIN;
+    void              (*m_handler)();
+    Ferraris::states  m_state;
+    unsigned long     m_timestamp;
+    unsigned long     m_timestampLast1;
+    unsigned long     m_timestampLast2;
+    unsigned long     m_revolutions;
+    unsigned int      m_rev_kWh;
+    unsigned int      m_debounce;
+    bool              m_changed;    // something has changed -> give info in loop()
+
+    static uint8_t    FINSTANCE; // used to identify instance
+};
+
+#if (FERRARIS_NUM < 1) || (FERRARIS_NUM > 7)
+  #error "Maximum of 7 Farraris meters allowed"
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,18 +80,6 @@
   - Over the air update of firmware
   - 4 meter counter (IR-Input pins)
 
- * Used pins
- * Internal LED       (D0) GPIO 16
- * IR Pin Messure 1   (D1) GPIO 05
- * IR Pin Messure 2   (D2) GPIO 04
- * IR Pin Messure 3   (D3) GPIO 00
- * free               (D4) GPIO 02
- * IR Pin Messure 4   (D5) GPIO 14
- * free               (D6) GPIO 12
- * free               (D7) GPIO 13
- * free               (D8) GPIO 15
- * free               (SDD3) GPIO 10
- *
 *********/
 #include <Arduino.h>
 #include <PubSubClient.h>
@@ -102,45 +90,13 @@
 #include "configManager.h"
 #include "dashboard.h"
 #include "timeSync.h"
+#include <time.h>    // time() ctime()
 #include <ArduinoJson.h>
 
+#include "ferraris.h"
 #include "mqtt_subscribe.h"
 #include "mqtt_publish.h"
 
-#define MINTIME 2    //in 10ms = 20ms
-
-bool lastState1 = 1;  // 0 = Silver->Red; 1 = Red->Silver
-bool lastState2 = 1;
-bool lastState3 = 1;
-bool lastState4 = 1;
-unsigned long lastmillis1 = 0;
-unsigned long pendingmillis1 = 0;
-unsigned long lastmillis2 = 0;
-unsigned long pendingmillis2 = 0;
-unsigned long lastmillis3 = 0;
-unsigned long pendingmillis3 = 0;
-unsigned long lastmillis4 = 0;
-unsigned long pendingmillis4 = 0;
-bool inbuf1[MINTIME];
-bool inbuf2[MINTIME];
-bool inbuf3[MINTIME];
-bool inbuf4[MINTIME];
-bool startup1=true;
-bool startup2=true;
-bool startup3=true;
-bool startup4=true;
-bool calcPower1Stat;
-bool calcPower2Stat;
-bool calcPower3Stat;
-bool calcPower4Stat;
-bool debStat1;
-bool debStat2;
-bool debStat3;
-bool debStat4;
-int loops_actual_1 = 0;
-int loops_actual_2 = 0;
-int loops_actual_3 = 0;
-int loops_actual_4 = 0;
 const int analogInPin = A0;   // ESP8266 Analog Pin ADC0 = A0
 
 int mqttPublishTime;          // last publish time in seconds
@@ -159,375 +115,109 @@ struct task
 task taskA = { .rate = 1000, .previous = 0 };
 task taskB = { .rate =  200, .previous = 0 };
 
-unsigned long debouncePrevious1 = 0;
-unsigned long debouncePrevious2 = 0;
-unsigned long debouncePrevious3 = 0;
-unsigned long debouncePrevious4 = 0;
 
-// ### Begin Subroutines
-// IR-Sensor Subs
-bool getInput(uint8_t pin) {
-  byte inchk=0;
-  for (byte i=0; i < 5; i++) {
-    inchk += digitalRead(pin);
-    delay(2);
-  }
-  if (inchk >= 3) return 1;
-  return 0;
-}
+// ----------------------------------------------------------------------------
+// helper functions
+// ----------------------------------------------------------------------------
 
-bool procInput1(bool state) {
-  byte inchk=0;
-  //Array shift
-  for (byte k = MINTIME-2; (k >= 0 && k < MINTIME); k--) {
-    inbuf1[k+1] = inbuf1[k];
-    inchk += inbuf1[k];
-  }
-
-  //New value
-  inbuf1[0] = state;
-  inchk += state;
-
-  //Return average
-  if (inchk > MINTIME/2) return 1;
-  return 0;
-}
-
-bool procInput2(bool state) {
-  byte inchk=0;
-  //Array shift
-  for (byte k = MINTIME-2; (k >= 0 && k < MINTIME); k--) {
-    inbuf2[k+1] = inbuf2[k];
-    inchk += inbuf2[k];
-  }
-
-  //New value
-  inbuf2[0] = state;
-  inchk += state;
-
-  //Return average
-  if (inchk > MINTIME/2) return 1;
-  return 0;
-}
-
-bool procInput3(bool state) {
-  byte inchk=0;
-  //Array shift
-  for (byte k = MINTIME-2; (k >= 0 && k < MINTIME); k--) {
-    inbuf3[k+1] = inbuf3[k];
-    inchk += inbuf3[k];
-  }
-
-  //New value
-  inbuf3[0] = state;
-  inchk += state;
-
-  //Return average
-  if (inchk > MINTIME/2) return 1;
-  return 0;
-}
-
-bool procInput4(bool state) {
-  byte inchk=0;
-  //Array shift
-  for (byte k = MINTIME-2; (k >= 0 && k < MINTIME); k--) {
-    inbuf4[k+1] = inbuf4[k];
-    inchk += inbuf4[k];
-  }
-
-  //New value
-  inbuf4[0] = state;
-  inchk += state;
-
-  //Return average
-  if (inchk > MINTIME/2) return 1;
-  return 0;
-}
-
-void IRAM_ATTR IRSensorHandle1(void) {
-
-   // IR Sensors
-  bool cur1 = getInput(IRPIN1);
-  cur1 = procInput1(cur1);
-
-  if (!debStat1) {
-    switch (lastState1) {
-      case 0: //Silver; Waiting for transition to red
-        if (cur1 != SILVER1) {
-          lastState1 = true;
-          pendingmillis1 = millis();
-          calcPower1Stat = true;
-          debouncePrevious1 = millis();
-          debStat1 = true;
-        }
-        break;
-      case 1: //Red; Waiting for transition to silver
-        if (cur1 != RED1) {
-          lastState1=false;
-          debouncePrevious1 = millis();
-          debStat1 = true;
-        }
-        break;
-    }
-  }
-}
-
-void IRAM_ATTR IRSensorHandle2(void) {
-
-   // IR Sensors
-  bool cur2 = getInput(IRPIN2);
-  cur2 = procInput2(cur2);
-
-  if (!debStat2) {
-    switch(lastState2) {
-    case 0: //Silver; Waiting for transition to red
-      if (cur2 != SILVER2) {
-        lastState2=true;
-        pendingmillis2 = millis();
-        calcPower2Stat = true;
-        debouncePrevious2 = millis();
-        debStat2 = true;
-      }
-      break;
-    case 1: //Red; Waiting for transition to silver
-      if (cur2 != RED2) {
-        lastState2=false;
-        debouncePrevious2 = millis();
-        debStat2 = true;
-      }
-      break;
-  }
-  }
-}
-
-void IRAM_ATTR IRSensorHandle3(void) {
-
-   // IR Sensors
-  bool cur3 = getInput(IRPIN3);
-  cur3 = procInput3(cur3);
-
-  if (!debStat3) {
-    switch (lastState3) {
-      case 0: //Silver; Waiting for transition to red
-        if (cur3 != SILVER3) {
-          lastState3=true;
-          pendingmillis3 = millis();
-          calcPower3Stat = true;
-          debouncePrevious3 = millis();
-          debStat3 = true;
-        }
-        break;
-      case 1: //Red; Waiting for transition to silver
-        if (cur3 != RED3) {
-          lastState3=false;
-          debouncePrevious3 = millis();
-          debStat3 = true;
-        }
-        break;
-    }
-  }
-}
-
-void IRAM_ATTR IRSensorHandle4(void) {
-
-   // IR Sensors
-  bool cur4 = getInput(IRPIN4);
-  cur4 = procInput4(cur4);
-
-  if (!debStat4) {
-    switch (lastState4) {
-      case 0: //Silver; Waiting for transition to red
-        if (cur4 != SILVER4) {
-          lastState4=true;
-          pendingmillis4 = millis();
-          calcPower4Stat = true;
-          debouncePrevious4 = millis();
-          debStat4 = true;
-        }
-        break;
-      case 1: //Red; Waiting for transition to silver
-        if (cur4 != RED4) {
-          lastState4=false;
-          debouncePrevious4 = millis();
-          debStat4 = true;
-        }
-        break;
-    }
-  }
-}
-
-void calcPower1(void) {
-  unsigned long took1 = pendingmillis1 - lastmillis1;
-  lastmillis1 = pendingmillis1;
-
-  if (!startup1) {
-    dash.data.kW_1 = 3600000.00 / took1 / configManager.data.meter_loops_count_1;
-    Serial.print(dash.data.kW_1);
-    Serial.print(" kW @ ");
-    Serial.print(took1);
-    Serial.println("ms");
-
-    /***
-    // adding float to meter count
-    float delta_meter1 = 1.0 / configManager.data.meter_loops_count_1;
-    configManager.data.meter_counter_reading_1 += delta_meter1;
-    ***/
-
-    // check if one KWh is gone (75 rpm then ++ kwh) and store values in file-system
-    Serial.print("loops_actual_1 :");
-    Serial.print(loops_actual_1);
-    Serial.print(" / ");
-    Serial.println(configManager.data.meter_loops_count_1);
-
-    if (loops_actual_1 < configManager.data.meter_loops_count_1) {
-      loops_actual_1++;
-    } else {
-      configManager.data.meter_counter_reading_1++;
-      loops_actual_1 = 1;
-      saveConfig = true;
-    }
-
-    Serial.print("meter_counter_reading_1 :");
-    Serial.print(configManager.data.meter_counter_reading_1);
-    Serial.println(" KWh");
-
-  } else {
-    startup1=false;
-  }
-}
-
-void calcPower2(void) {
-  unsigned long took2 = pendingmillis2 - lastmillis2;
-  lastmillis2 = pendingmillis2;
-
-  if (!startup2) {
-    dash.data.kW_2 = 3600000.00 / took2 / configManager.data.meter_loops_count_2;
-    Serial.print(dash.data.kW_2);
-    Serial.print(" kW @ ");
-    Serial.print(took2);
-    Serial.println("ms");
-
-    /***
-    // adding float to meter count
-    float delta_meter2 = 1.0 / configManager.data.meter_loops_count_2;
-    configManager.data.meter_counter_reading_2 += delta_meter2;
-    ***/
-
-    // check if one KWh is gone (75 rpm then ++ kwh) and store values in file-system
-    Serial.print("loops_actual_2 :");
-    Serial.print(loops_actual_2);
-    Serial.print(" / ");
-    Serial.println(configManager.data.meter_loops_count_2);
-
-    if (loops_actual_2 < configManager.data.meter_loops_count_2) {
-      loops_actual_2++;
-    } else {
-      configManager.data.meter_counter_reading_2++;
-      loops_actual_2 = 1;
-      saveConfig = true;
-    }
-
-    Serial.print("meter_counter_reading_2 :");
-    Serial.print(configManager.data.meter_counter_reading_2);
-    Serial.println(" KWh");
-
-  } else {
-    startup2=false;
-  }
-}
-
-void calcPower3(void) {
-  unsigned long took3 = pendingmillis3 - lastmillis3;
-  lastmillis3 = pendingmillis3;
-
-  if (!startup3) {
-    dash.data.kW_3 = 3600000.00 / took3 / configManager.data.meter_loops_count_3;
-    Serial.print(dash.data.kW_3);
-    Serial.print(" kW @ ");
-    Serial.print(took3);
-    Serial.println("ms");
-
-    /***
-    // adding float to meter count
-    float delta_meter3 = 1.0 / configManager.data.meter_loops_count_3;
-    configManager.data.meter_counter_reading_3 += delta_meter3;
-    ***/
-
-    // check if one KWh is gone (75 rpm then ++ kwh) and store values in file-system
-    Serial.print("loops_actual_3 :");
-    Serial.print(loops_actual_3);
-    Serial.print(" / ");
-    Serial.println(configManager.data.meter_loops_count_3);
-
-    if (loops_actual_3 < configManager.data.meter_loops_count_3) {
-      loops_actual_3++;
-    } else {
-      configManager.data.meter_counter_reading_3++;
-      loops_actual_3 = 1;
-      saveConfig = true;
-    }
-
-    Serial.print("meter_counter_reading_3 :");
-    Serial.print(configManager.data.meter_counter_reading_3);
-    Serial.println(" KWh");
-
-  } else {
-    startup3=false;
-  }
-}
-
-void calcPower4(void) {
-  unsigned long took4 = pendingmillis4 - lastmillis4;
-  lastmillis4 = pendingmillis4;
-
-  if (!startup4) {
-    dash.data.kW_4 = 3600000.00 / took4 / configManager.data.meter_loops_count_4;
-    Serial.print(dash.data.kW_4);
-    Serial.print(" kW @ ");
-    Serial.print(took4);
-    Serial.println("ms");
-
-    /***
-    // adding float to meter count
-    float delta_meter4 = 1.0 / configManager.data.meter_loops_count_4;
-    configManager.data.meter_counter_reading_4 += delta_meter4;
-    ***/
-
-    // check if one KWh is gone (75 rpm then ++ kwh) and store values in file-system
-    Serial.print("loops_actual_4 :");
-    Serial.print(loops_actual_4);
-    Serial.print(" / ");
-    Serial.println(configManager.data.meter_loops_count_4);
-
-    if (loops_actual_4 < configManager.data.meter_loops_count_4) {
-      loops_actual_4++;
-    } else {
-      configManager.data.meter_counter_reading_4++;
-      loops_actual_4 = 1;
-      saveConfig = true;
-    }
-
-    Serial.print("meter_counter_reading_4 :");
-    Serial.print(configManager.data.meter_counter_reading_4);
-    Serial.println(" KWh");
-
-  } else {
-    startup4=false;
-  }
+void copyConfig2Ferraris()
+{
+  Ferraris::getInstance(0).set_U_kWh      (configManager.data.meter_loops_count_1);
+  Ferraris::getInstance(0).set_revolutions(configManager.data.meter_counter_reading_1 * configManager.data.meter_loops_count_1);
+  Ferraris::getInstance(0).set_debounce   (configManager.data.meter_debounce_1);
+#if FERRARIS_NUM > 1
+  Ferraris::getInstance(1).set_U_kWh      (configManager.data.meter_loops_count_2);
+  Ferraris::getInstance(1).set_revolutions(configManager.data.meter_counter_reading_2 * configManager.data.meter_loops_count_2);
+  Ferraris::getInstance(1).set_debounce   (configManager.data.meter_debounce_2);
+#endif
+#if FERRARIS_NUM > 2
+  Ferraris::getInstance(2).set_U_kWh      (configManager.data.meter_loops_count_3);
+  Ferraris::getInstance(2).set_revolutions(configManager.data.meter_counter_reading_3 * configManager.data.meter_loops_count_3);
+  Ferraris::getInstance(2).set_debounce   (configManager.data.meter_debounce_3);
+#endif
+#if FERRARIS_NUM > 3
+  Ferraris::getInstance(3).set_U_kWh      (configManager.data.meter_loops_count_4);
+  Ferraris::getInstance(3).set_revolutions(configManager.data.meter_counter_reading_4 * configManager.data.meter_loops_count_4);
+  Ferraris::getInstance(3).set_debounce   (configManager.data.meter_debounce_4);
+#endif
+#if FERRARIS_NUM > 4
+  Ferraris::getInstance(4).set_U_kWh      (configManager.data.meter_loops_count_5);
+  Ferraris::getInstance(4).set_revolutions(configManager.data.meter_counter_reading_5 * configManager.data.meter_loops_count_5);
+  Ferraris::getInstance(4).set_debounce   (configManager.data.meter_debounce_5;
+#endif
+#if FERRARIS_NUM > 5
+  Ferraris::getInstance(5).set_U_kWh      (configManager.data.meter_loops_count_6);
+  Ferraris::getInstance(5).set_revolutions(configManager.data.meter_counter_reading_6 * configManager.data.meter_loops_count_6);
+  Ferraris::getInstance(5).set_debounce   (configManager.data.meter_debounce_6);
+#endif
+#if FERRARIS_NUM > 6
+  Ferraris::getInstance(6).set_U_kWh      (configManager.data.meter_loops_count_7);
+  Ferraris::getInstance(6).set_revolutions(configManager.data.meter_counter_reading_7 * configManager.data.meter_loops_count_7);
+  Ferraris::getInstance(6).set_debounce   (configManager.data.meter_debounce_7);
+#endif
 }
 
 // update Dashboard with current measurement values
-void updateDashboard()
+void updateDashboard(uint8_t F)
 {
-  dash.data.kWh_1 = configManager.data.meter_counter_reading_1;
-  dash.data.kWh_2 = configManager.data.meter_counter_reading_2;
-  dash.data.kWh_3 = configManager.data.meter_counter_reading_3;
-  dash.data.kWh_4 = configManager.data.meter_counter_reading_4;
+  assert(F < FERRARIS_NUM);
 
-  dash.data.revolutions_1 = loops_actual_1;
-  dash.data.revolutions_2 = loops_actual_2;
-  dash.data.revolutions_3 = loops_actual_3;
-  dash.data.revolutions_4 = loops_actual_4;
+  switch (F) {
+    case 0:
+      dash.data.revolutions_1 = Ferraris::getInstance(0).get_revolutions();
+      dash.data.kWh_1         = Ferraris::getInstance(0).get_kWh();
+      dash.data.W_1           = Ferraris::getInstance(0).get_W();
+      configManager.data.meter_counter_reading_1 = Ferraris::getInstance(0).get_kWh();
+      break;
+#if FERRARIS_NUM > 1
+    case 1:
+      dash.data.revolutions_2 = Ferraris::getInstance(1).get_revolutions();
+      dash.data.kWh_2         = Ferraris::getInstance(1).get_kWh();
+      dash.data.W_2           = Ferraris::getInstance(1).get_W();
+      configManager.data.meter_counter_reading_2 = Ferraris::getInstance(1).get_kWh();
+      break;
+#endif
+#if FERRARIS_NUM > 2
+    case 2:
+      dash.data.revolutions_3 = Ferraris::getInstance(2).get_revolutions();
+      dash.data.kWh_3         = Ferraris::getInstance(2).get_kWh();
+      dash.data.W_3           = Ferraris::getInstance(2).get_W();
+      configManager.data.meter_counter_reading_3 = Ferraris::getInstance(2).get_kWh();
+      break;
+#endif
+#if FERRARIS_NUM > 3
+    case 3:
+      dash.data.revolutions_4 = Ferraris::getInstance(3).get_revolutions();
+      dash.data.kWh_4         = Ferraris::getInstance(3).get_kWh();
+      dash.data.W_4           = Ferraris::getInstance(3).get_W();
+      configManager.data.meter_counter_reading_4 = Ferraris::getInstance(3).get_kWh();
+      break;
+#endif
+#if FERRARIS_NUM > 4
+    case 4:
+      dash.data.revolutions_5 = Ferraris::getInstance(1).get_revolutions();
+      dash.data.kWh_5         = Ferraris::getInstance(1).get_kWh();
+      dash.data.W_5           = Ferraris::getInstance(1).get_W();
+      configManager.data.meter_counter_reading_5 = Ferraris::getInstance(4).get_kWh();
+      break;
+#endif
+#if FERRARIS_NUM > 5
+    case 5:
+      dash.data.revolutions_6 = Ferraris::getInstance(2).get_revolutions();
+      dash.data.kWh_6         = Ferraris::getInstance(2).get_kWh();
+      dash.data.W_6           = Ferraris::getInstance(2).get_W();
+      configManager.data.meter_counter_reading_6 = Ferraris::getInstance(5).get_kWh();
+      break;
+#endif
+#if FERRARIS_NUM > 6
+    case 6:
+      dash.data.revolutions_7 = Ferraris::getInstance(3).get_revolutions();
+      dash.data.kWh_7         = Ferraris::getInstance(3).get_kWh();
+      dash.data.W_7           = Ferraris::getInstance(3).get_W();
+      configManager.data.meter_counter_reading_7 = Ferraris::getInstance(6).get_kWh();
+      break;
+#endif
+  }
 }
 
 // update Dashboard with graph plot data, only necessary when client is connected
@@ -539,13 +229,29 @@ void updateDashboardGraph()
 
   dash.data.Sensor = analogRead(analogInPin);
 
-  dash.data.Impuls_Z1 = lastState1;
-  dash.data.Impuls_Z2 = lastState2;
-  dash.data.Impuls_Z3 = lastState3;
-  dash.data.Impuls_Z4 = lastState4;
-}
+  dash.data.Impuls_Z1 = !Ferraris::getInstance(0).get_state();
+#if FERRARIS_NUM > 1
+  dash.data.Impuls_Z2 = !Ferraris::getInstance(1).get_state();
+#endif
+#if FERRARIS_NUM > 2
+  dash.data.Impuls_Z3 = !Ferraris::getInstance(2).get_state();
+#endif
+#if FERRARIS_NUM > 3
+  dash.data.Impuls_Z4 = !Ferraris::getInstance(3).get_state();
+#endif
+#if FERRARIS_NUM > 4
+  dash.data.Impuls_Z4 = !Ferraris::getInstance(4).get_state();
+#endif
+#if FERRARIS_NUM > 5
+  dash.data.Impuls_Z4 = !Ferraris::getInstance(5).get_state();
+#endif
+#if FERRARIS_NUM > 6
+  dash.data.Impuls_Z4 = !Ferraris::getInstance(6).get_state();
+#endif
 
-// ### End Subroutines
+  for (uint8_t F=0; F<FERRARIS_NUM; F++)
+    updateDashboard(F);
+}
 
 
 void setup() {
@@ -554,43 +260,31 @@ void setup() {
   LittleFS.begin();
   GUI.begin();
   configManager.begin();
+  configManager.setConfigSaveCallback( copyConfig2Ferraris );
+  // WiFi
+  WiFi.hostname(configManager.data.wifi_hostname);
+  WiFi.setAutoReconnect(true);
   WiFiManager.begin(configManager.data.projectName);
   timeSync.begin();
   dash.begin(taskB.rate);
 
-  // WiFi
-  WiFi.hostname(configManager.data.wifi_hostname);
-  WiFi.begin();
-  WiFi.setAutoReconnect(true);
-
   // IR-Sensor
-  pinMode(IRPIN1, INPUT_PULLUP);
-  pinMode(IRPIN2, INPUT_PULLUP);
-  pinMode(IRPIN3, INPUT_PULLUP);
-  pinMode(IRPIN4, INPUT_PULLUP);
-
-  // Printout the IP address
-  IPAddress ip;
-  ip = WiFi.localIP();
-  Serial.println("Connected.");
-  Serial.print("IP-address : ");
-  Serial.println(ip);
+  copyConfig2Ferraris();
+  for (uint8_t F=0; F<FERRARIS_NUM; F++) {
+    Ferraris::getInstance(F).begin();
+    updateDashboard(F);
+  }
 
   MQTTclient.setServer(configManager.data.mqtt_server, configManager.data.mqtt_port);
   MQTTclient.setCallback(parseMQTTmessage);
   MQTTclient.setBufferSize(320); // TODO: maybe we can calculate this based on the largest assumed request + its parameters?
 
   memcpy(dash.data.Version, "v.0.96", 6);
-  updateDashboard();
 
   // activate port for status LED
   pinMode(LED_BUILTIN, OUTPUT);
-
-  attachInterrupt(digitalPinToInterrupt(IRPIN1), IRSensorHandle1, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(IRPIN2), IRSensorHandle2, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(IRPIN3), IRSensorHandle3, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(IRPIN4), IRSensorHandle4, CHANGE);
 }
+
 
 void loop() {
   // framework things
@@ -600,11 +294,15 @@ void loop() {
   dash.loop();
   MQTTclient.loop();
 
+  for (uint8_t F=0; F<FERRARIS_NUM; F++)
+    if (Ferraris::getInstance(F).loop()) {
+      updateDashboard(F);
+    }
+
   // tasks
   if (taskA.previous == 0 || (millis() - taskA.previous > taskA.rate)) {
     taskA.previous = millis();
     if (WiFi.status() == WL_CONNECTED) {
-      updateDashboard();
       checkMQTTconnection();
 
       if (mqttPublishTime <= configManager.data.mqtt_interval) {
@@ -624,60 +322,10 @@ void loop() {
     digitalWrite(LED_BUILTIN, (WiFi.status() == WL_CONNECTED));
   }
 
-  if (debouncePrevious1 == 0 || (millis() - debouncePrevious1 > configManager.data.meter_debounce_1)) {
-    debouncePrevious1 = millis();
-    if (debStat1) {
-      debStat1 = false;
-    }
-  }
-
-  if (debouncePrevious2 == 0 || (millis() - debouncePrevious2 > configManager.data.meter_debounce_2)) {
-    debouncePrevious2 = millis();
-    if (debStat2) {
-      debStat2 = false;
-    }
-  }
-
-  if (debouncePrevious3 == 0 || (millis() - debouncePrevious3 > configManager.data.meter_debounce_3)) {
-    debouncePrevious3 = millis();
-    if (debStat3) {
-      debStat3 = false;
-    }
-  }
-
-  if (debouncePrevious4 == 0 || (millis() - debouncePrevious4 > configManager.data.meter_debounce_4)) {
-    debouncePrevious4 = millis();
-    if (debStat4) {
-      debStat4 = false;
-    }
-  }
-
-  if (calcPower1Stat) {
-    calcPower1();
-    calcPower1Stat = false;
-  } else if (calcPower2Stat) {
-    calcPower2();
-    calcPower2Stat = false;
-  } else if (calcPower3Stat) {
-    calcPower3();
-    calcPower3Stat = false;
-  } else if (calcPower4Stat) {
-    calcPower4();
-    calcPower4Stat = false;
-  }
-
   if (saveConfig) {
-    Serial.println("[SAVE]...");
+    Serial.println("[save config]...");
     saveConfig = false;
-    detachInterrupt(digitalPinToInterrupt(IRPIN1));
-    detachInterrupt(digitalPinToInterrupt(IRPIN2));
-    detachInterrupt(digitalPinToInterrupt(IRPIN3));
-    detachInterrupt(digitalPinToInterrupt(IRPIN4));
     configManager.save();   // may take ~50ms
-    attachInterrupt(digitalPinToInterrupt(IRPIN1), IRSensorHandle1, CHANGE);
-    attachInterrupt(digitalPinToInterrupt(IRPIN2), IRSensorHandle2, CHANGE);
-    attachInterrupt(digitalPinToInterrupt(IRPIN3), IRSensorHandle3, CHANGE);
-    attachInterrupt(digitalPinToInterrupt(IRPIN4), IRSensorHandle4, CHANGE);
-    Serial.println("...[SAVE finished]");
+    Serial.println("...[save config]");
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,19 @@
   The ESP firmware update can be done via "Over-The-Air".
 
   History
+  Ver. 0.97 (202302xx)
+  - use "Ferraris" objects to capsule code and state for each meter
+  - allow 1..7 meters just by one #define
+  - switch from [kW] -> [W] for live consumption, so we do not need float there
+  - use the count of revolutions as source of total consumption [kWh] to allow fractional part there and no float in IRQ handler
+
+  Ver. 0.96 (20230130)
+  - first part of code refactoring: split into multiple source files
+  - use header lines in Dashboard and Configuration for more structured view
+  - minor changes to improve stability
+  - use blue LED to show lost WiFi
+  - fix: value of analog sensor in Dashboard
+
   Ver. 0.95 (20230121)
   - Fixed: WiFi automatic reconnect after WiFi loss
   - Fixed: prevent watchdog reboot during long running MQTT update
@@ -279,7 +292,7 @@ void setup() {
   MQTTclient.setCallback(parseMQTTmessage);
   MQTTclient.setBufferSize(320); // TODO: maybe we can calculate this based on the largest assumed request + its parameters?
 
-  memcpy(dash.data.Version, "v.0.96", 6);
+  memcpy(dash.data.Version, "v.0.97", 6);
 
   // activate port for status LED
   pinMode(LED_BUILTIN, OUTPUT);

--- a/src/mqtt_publish.cpp
+++ b/src/mqtt_publish.cpp
@@ -6,6 +6,7 @@
 // access to data on web server
 #include "configManager.h"
 #include "dashboard.h"
+#include "ferraris.h"
 
 
 String getTopicName(int meter, String measurement) {
@@ -15,7 +16,7 @@ String getTopicName(int meter, String measurement) {
   topic = topic + String(meter);
   topic = topic +"/";
   topic = topic + measurement;
-  
+
   return topic;
 }
 
@@ -31,19 +32,20 @@ String getHATopicName(String mqtt_type, char uniqueId[30]) {
 
 String getSetTopicName(int meter, String measurement) {
   String  topic = getTopicName(meter,measurement);
-  topic = topic + "/set"; 
-  
+  topic = topic + "/set";
+
   return topic;
 }
 
 
 // declare some external stuff -> todo: better refactoring
 extern PubSubClient MQTTclient;
+/*
 void IRAM_ATTR IRSensorHandle1();
 void IRAM_ATTR IRSensorHandle2();
 void IRAM_ATTR IRSensorHandle3();
 void IRAM_ATTR IRSensorHandle4();
-
+*/
 
 static int mqttReconnect;   // timeout for reconnecting MQTT Server
 
@@ -53,10 +55,12 @@ void checkMQTTconnection(void)
     mqttReconnect = 0;    // reset reconnect timeout
     // reconnect to MQTT Server
     if (!MQTTclient.connected()) {
+      /*
       detachInterrupt(digitalPinToInterrupt(IRPIN1));
       detachInterrupt(digitalPinToInterrupt(IRPIN2));
       detachInterrupt(digitalPinToInterrupt(IRPIN3));
       detachInterrupt(digitalPinToInterrupt(IRPIN4));
+      */
       dash.data.MQTT_Connected = false;
       Serial.println("Attempting MQTT connection...");
       // Create a random client ID
@@ -90,12 +94,14 @@ void checkMQTTconnection(void)
         Serial.print(MQTTclient.state());
         Serial.println(" try again in one minute");
       }
+      /*
       attachInterrupt(digitalPinToInterrupt(IRPIN1), IRSensorHandle1, CHANGE);
       attachInterrupt(digitalPinToInterrupt(IRPIN2), IRSensorHandle2, CHANGE);
       attachInterrupt(digitalPinToInterrupt(IRPIN3), IRSensorHandle3, CHANGE);
       attachInterrupt(digitalPinToInterrupt(IRPIN4), IRSensorHandle4, CHANGE);
+      */
     }
-  }    
+  }
 }
 
 
@@ -104,10 +110,12 @@ char message_buffer[MSG_BUFFER_SIZE];
 
 void publishMQTT(void)
 {
+  /*
   detachInterrupt(digitalPinToInterrupt(IRPIN1));
   detachInterrupt(digitalPinToInterrupt(IRPIN2));
   detachInterrupt(digitalPinToInterrupt(IRPIN3));
   detachInterrupt(digitalPinToInterrupt(IRPIN4));
+  */
 
   String topic;
   String cmdTopic;
@@ -231,87 +239,77 @@ void publishMQTT(void)
   }
 
   // Meter #1
-  topic = getTopicName(1,"Stand");
-  dtostrf(configManager.data.meter_counter_reading_1, 7, 3, message_buffer);
+  topic = getTopicName(1, "Stand");
+  dtostrf(Ferraris::getInstance(0).get_kWh(), 1, 1, message_buffer);
   MQTTclient.publish(topic.c_str(), message_buffer, true);
 
-  topic = getTopicName(1,"KW");
-  char char_Leistung_Zaehler1[6];
-  dtostrf(dash.data.kW_1, 4, 3, char_Leistung_Zaehler1);
-  MQTTclient.publish(topic.c_str(), char_Leistung_Zaehler1, true);
+  topic = getTopicName(1, "W");
+  dtostrf(Ferraris::getInstance(0).get_W(), 1, 1, message_buffer);
+  MQTTclient.publish(topic.c_str(), message_buffer, false);
 
-  topic = getTopicName(1,"UKWh");
-  char char_meter_loop_counts1[5];
-  dtostrf(configManager.data.meter_loops_count_1,4,0, char_meter_loop_counts1);
-  MQTTclient.publish(topic.c_str(), char_meter_loop_counts1, true);
+  topic = getTopicName(1, "UKWh");
+  itoa(configManager.data.meter_loops_count_1, message_buffer, 10);
+  MQTTclient.publish(topic.c_str(), message_buffer, true);
 
-  topic = getTopicName(1,"Entprellzeit");
-  char char_debounce_1[4];
-  dtostrf(configManager.data.meter_debounce_1,3,0, char_debounce_1);
-  MQTTclient.publish(topic.c_str(), char_debounce_1, true);
+  topic = getTopicName(1, "Entprellzeit");
+  itoa(configManager.data.meter_debounce_1, message_buffer, 10);
+  MQTTclient.publish(topic.c_str(), message_buffer, true);
 
   // Meter #2
-  topic = getTopicName(2,"Stand");
-  dtostrf(configManager.data.meter_counter_reading_2, 7, 3, message_buffer);
+  topic = getTopicName(2, "Stand");
+  dtostrf(Ferraris::getInstance(1).get_kWh(), 1, 1, message_buffer);
   MQTTclient.publish(topic.c_str(), message_buffer, true);
 
-  topic = getTopicName(2,"KW");
-  char char_Leistung_Zaehler2[6];
-  dtostrf(dash.data.kW_2, 4, 3, char_Leistung_Zaehler2);
-  MQTTclient.publish(topic.c_str(), char_Leistung_Zaehler2, true);
+  topic = getTopicName(2, "W");
+  dtostrf(Ferraris::getInstance(1).get_W(), 1, 1, message_buffer);
+  MQTTclient.publish(topic.c_str(), message_buffer, false);
 
-  topic = getTopicName(2,"UKWh");
-  char char_meter_loop_counts2[5];
-  dtostrf(configManager.data.meter_loops_count_2,4,0, char_meter_loop_counts2);
-  MQTTclient.publish(topic.c_str(), char_meter_loop_counts2, true);
+  topic = getTopicName(2, "UKWh");
+  itoa(configManager.data.meter_loops_count_2, message_buffer, 10);
+  MQTTclient.publish(topic.c_str(), message_buffer, true);
 
   topic = getTopicName(2,"Entprellzeit");
-  char char_debounce_2[4];
-  dtostrf(configManager.data.meter_debounce_2,3,0, char_debounce_2);
-  MQTTclient.publish(topic.c_str(), char_debounce_2, true);
+  itoa(configManager.data.meter_debounce_2, message_buffer, 10);
+  MQTTclient.publish(topic.c_str(), message_buffer, true);
 
   // Meter #3
-  topic = getTopicName(3,"Stand");
-  dtostrf(configManager.data.meter_counter_reading_3, 7, 3, message_buffer);
+  topic = getTopicName(3, "Stand");
+  dtostrf(Ferraris::getInstance(2).get_kWh(), 1, 1, message_buffer);
   MQTTclient.publish(topic.c_str(), message_buffer, true);
 
-  topic = getTopicName(3,"KW");
-  char char_Leistung_Zaehler3[6];
-  dtostrf(dash.data.kW_3, 4, 3, char_Leistung_Zaehler3);
-  MQTTclient.publish(topic.c_str(), char_Leistung_Zaehler3, true);
+  topic = getTopicName(3, "W");
+  dtostrf(Ferraris::getInstance(2).get_W(), 1, 1, message_buffer);
+  MQTTclient.publish(topic.c_str(), message_buffer, false);
 
-  topic = getTopicName(3,"UKWh");
-  char char_meter_loop_counts3[5];
-  dtostrf(configManager.data.meter_loops_count_3,4,0, char_meter_loop_counts3);
-  MQTTclient.publish(topic.c_str(), char_meter_loop_counts3, true);
+  topic = getTopicName(3, "UKWh");
+  itoa(configManager.data.meter_loops_count_3, message_buffer, 10);
+  MQTTclient.publish(topic.c_str(), message_buffer, true);
 
-  topic = getTopicName(3,"Entprellzeit");
-  char char_debounce_3[4];
-  dtostrf(configManager.data.meter_debounce_3,3,0, char_debounce_3);
-  MQTTclient.publish(topic.c_str(), char_debounce_3, true);
+  topic = getTopicName(3, "Entprellzeit");
+  itoa(configManager.data.meter_debounce_3, message_buffer, 10);
+  MQTTclient.publish(topic.c_str(), message_buffer, true);
 
   // Meter #4
-  topic = getTopicName(4,"Stand");
-  dtostrf(configManager.data.meter_counter_reading_4, 7, 3, message_buffer);
+  topic = getTopicName(4, "Stand");
+  dtostrf(Ferraris::getInstance(3).get_kWh(), 1, 1, message_buffer);
   MQTTclient.publish(topic.c_str(), message_buffer, true);
 
-  topic = getTopicName(4,"KW");
-  char char_Leistung_Zaehler4[6];
-  dtostrf(dash.data.kW_4, 4, 3, char_Leistung_Zaehler4);
-  MQTTclient.publish(topic.c_str(), char_Leistung_Zaehler4, true);
+  topic = getTopicName(4, "W");
+  dtostrf(Ferraris::getInstance(3).get_W(), 1, 1, message_buffer);
+  MQTTclient.publish(topic.c_str(), message_buffer, false);
 
-  topic = getTopicName(4,"UKWh");
-  char char_meter_loop_counts4[5];
-  dtostrf(configManager.data.meter_loops_count_4,4,0, char_meter_loop_counts4);
-  MQTTclient.publish(topic.c_str(), char_meter_loop_counts4, true);
+  topic = getTopicName(4, "UKWh");
+  itoa(configManager.data.meter_loops_count_4, message_buffer, 10);
+  MQTTclient.publish(topic.c_str(), message_buffer, true);
 
-  topic = getTopicName(4,"Entprellzeit");
-  char char_debounce_4[4];
-  dtostrf(configManager.data.meter_debounce_4,3,0, char_debounce_4);
-  MQTTclient.publish(topic.c_str(), char_debounce_4, true);
+  topic = getTopicName(4, "Entprellzeit");
+  itoa(configManager.data.meter_debounce_4, message_buffer, 10);
+  MQTTclient.publish(topic.c_str(), message_buffer, true);
 
+  /*
   attachInterrupt(digitalPinToInterrupt(IRPIN1), IRSensorHandle1, CHANGE);
   attachInterrupt(digitalPinToInterrupt(IRPIN2), IRSensorHandle2, CHANGE);
   attachInterrupt(digitalPinToInterrupt(IRPIN3), IRSensorHandle3, CHANGE);
   attachInterrupt(digitalPinToInterrupt(IRPIN4), IRSensorHandle4, CHANGE);
+  */
 }

--- a/src/mqtt_subscribe.cpp
+++ b/src/mqtt_subscribe.cpp
@@ -1,4 +1,6 @@
+#include "ferraris.h"
 #include "mqtt_subscribe.h"
+
 #include "configManager.h"
 
 
@@ -37,13 +39,13 @@ void parseMQTTmessage(char* topic, byte* payload, unsigned int length)
     debounceTimeCmdTopic = getSetTopicName(i+1, "Entprellzeit");
 
     if (t == ukwhCmdTopic){
-      int16_t meters_per_loop = p.toInt();
+      uint16_t meters_per_loop = p.toInt();
       switch (i+1) {
         case 1:
           Serial.print("Setting configManager.data.meter_loops_count_1 to ");
           Serial.print(meters_per_loop);
           Serial.println();
-          configManager.data.meter_loops_count_1=meters_per_loop;
+          configManager.data.meter_loops_count_1 = meters_per_loop;
           saveConfig = true;
           processed  = true;
           break;
@@ -51,7 +53,7 @@ void parseMQTTmessage(char* topic, byte* payload, unsigned int length)
           Serial.print("Setting configManager.data.meter_loops_count_2 to ");
           Serial.print(meters_per_loop);
           Serial.println();
-          configManager.data.meter_loops_count_2=meters_per_loop;
+          configManager.data.meter_loops_count_2 = meters_per_loop;
           saveConfig = true;
           processed  = true;
           break;
@@ -59,7 +61,7 @@ void parseMQTTmessage(char* topic, byte* payload, unsigned int length)
           Serial.print("Setting configManager.data.meter_loops_count_3 to ");
           Serial.print(meters_per_loop);
           Serial.println();
-          configManager.data.meter_loops_count_3=meters_per_loop;
+          configManager.data.meter_loops_count_3 = meters_per_loop;
           saveConfig = true;
           processed  = true;
           break;
@@ -67,7 +69,7 @@ void parseMQTTmessage(char* topic, byte* payload, unsigned int length)
           Serial.print("Setting configManager.data.meter_loops_count_4 to ");
           Serial.print(meters_per_loop);
           Serial.println();
-          configManager.data.meter_loops_count_4=meters_per_loop;
+          configManager.data.meter_loops_count_4 = meters_per_loop;
           saveConfig = true;
           processed  = true;
           break;
@@ -82,13 +84,13 @@ void parseMQTTmessage(char* topic, byte* payload, unsigned int length)
     }
 
     if (t == kwhCmdTopic) {
-      int16_t meter_value = p.toInt();
+      float meter_value = p.toFloat();
       switch (i+1) {
         case 1:
           Serial.print("Setting configManager.data.meter_counter_reading_1 to ");
           Serial.print(meter_value);
           Serial.println();
-          configManager.data.meter_counter_reading_1=meter_value;
+          configManager.data.meter_counter_reading_1 = meter_value;
           saveConfig = true;
           processed  = true;
           break;
@@ -96,7 +98,7 @@ void parseMQTTmessage(char* topic, byte* payload, unsigned int length)
           Serial.print("Setting configManager.data.meter_counter_reading_2 to ");
           Serial.print(meter_value);
           Serial.println();
-          configManager.data.meter_counter_reading_2=meter_value;
+          configManager.data.meter_counter_reading_2 = meter_value;
           saveConfig = true;
           processed  = true;
           break;
@@ -104,7 +106,7 @@ void parseMQTTmessage(char* topic, byte* payload, unsigned int length)
           Serial.print("Setting configManager.data.meter_counter_reading_3 to ");
           Serial.print(meter_value);
           Serial.println();
-          configManager.data.meter_counter_reading_3=meter_value;
+          configManager.data.meter_counter_reading_3 = meter_value;
           saveConfig = true;
           processed  = true;
           break;
@@ -112,7 +114,7 @@ void parseMQTTmessage(char* topic, byte* payload, unsigned int length)
           Serial.print("Setting configManager.data.meter_counter_reading_4 to ");
           Serial.print(meter_value);
           Serial.println();
-          configManager.data.meter_counter_reading_4=meter_value;
+          configManager.data.meter_counter_reading_4 = meter_value;
           saveConfig = true;
           processed  = true;
           break;
@@ -127,7 +129,7 @@ void parseMQTTmessage(char* topic, byte* payload, unsigned int length)
     }
 
     if (t == debounceTimeCmdTopic) {
-      int16_t debounce_value = p.toInt();
+      uint16_t debounce_value = p.toInt();
       switch (i+1) {
         case 1:
           Serial.print("Setting configManager.data.debounce_1 to ");


### PR DESCRIPTION
- use "Ferraris" objects to capsule code and state for each meter
- allow 1..7 meters just by one #define
- switch from [kW] -> [W] for live consumption, so we do not need float there
- use the count of revolutions as source of total consumption [kWh] to allow fractional part there and no float in IRQ handler
