### PR TITLE
allow backwards counting

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -97,6 +97,12 @@
         "value": "80"
     },
     {
+        "name": "meter_twoway_1",
+        "label": "Dual direction count mode",
+        "type": "bool",
+        "value": false
+    },
+    {
         "type": "header",
         "text": "Zähler 2"
     },
@@ -118,6 +124,12 @@
         "label": "Entprellzeit [ms]",
         "type": "uint16_t",
         "value": "80"
+    },
+    {
+        "name": "meter_twoway_2",
+        "label": "Dual direction count mode",
+        "type": "bool",
+        "value": false
     },
     {
         "type": "header",
@@ -143,6 +155,12 @@
         "value": "80"
     },
     {
+        "name": "meter_twoway_3",
+        "label": "Dual direction count mode",
+        "type": "bool",
+        "value": false
+    },
+    {
         "type": "header",
         "text": "Zähler 4"
     },
@@ -164,5 +182,11 @@
         "label": "Entprellzeit [ms]",
         "type": "uint16_t",
         "value": "80"
+    },
+    {
+        "name": "meter_twoway_4",
+        "label": "Dual direction count mode",
+        "type": "bool",
+        "value": false
     }
 ]

--- a/dashboard.json
+++ b/dashboard.json
@@ -17,20 +17,6 @@
         "direction": "display"
     },
     {
-        "name": "WLAN_RSSI",
-        "type": "int8_t",
-        "direction": "display",
-        "display": "graph",
-        "xaxis": 50
-    },
-    {
-        "name": "Sensor",
-        "type": "int16_t",
-        "direction": "display",
-        "display": "graph",
-        "xaxis": 50
-    },
-    {
         "name": "Impuls_Z1",
         "type": "bool",
         "direction": "display",
@@ -72,7 +58,7 @@
     {
         "name": "W_1",
         "label": "Leistung [W]",
-        "type": "uint16_t",
+        "type": "int16_t",
         "digits": 3,
         "direction": "display"
     },
@@ -97,7 +83,7 @@
     {
         "name": "W_2",
         "label": "Leistung [W]",
-        "type": "uint16_t",
+        "type": "int16_t",
         "digits": 3,
         "direction": "display"
     },
@@ -122,7 +108,7 @@
     {
         "name": "W_3",
         "label": "Leistung [W]",
-        "type": "uint16_t",
+        "type": "int16_t",
         "digits": 3,
         "direction": "display"
     },
@@ -147,7 +133,7 @@
     {
         "name": "W_4",
         "label": "Leistung [W]",
-        "type": "uint16_t",
+        "type": "int16_t",
         "digits": 3,
         "direction": "display"
     },
@@ -157,5 +143,19 @@
         "type": "float",
         "digits": 1,
         "direction": "display"
+    },
+    {
+        "name": "Sensor",
+        "type": "int16_t",
+        "direction": "display",
+        "display": "graph",
+        "xaxis": 50
+    },
+    {
+        "name": "WLAN_RSSI",
+        "type": "int8_t",
+        "direction": "display",
+        "display": "graph",
+        "xaxis": 50
     }
 ]

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:nodemcuv2]
-platform = espressif8266@3.0.0
+platform = espressif8266
 board = nodemcuv2
 framework = arduino
 board_build.f_cpu = 160000000L
@@ -17,7 +17,7 @@ upload_speed = 921600
 monitor_speed = 115200
 build_type = debug
 monitor_filters = esp8266_exception_decoder
-lib_deps = 
+lib_deps =
 	ArduinoJson
 	https://github.com/maakbaas/esp8266-iot-framework
 	me-no-dev/ESP Async WebServer @ ^1.2.3
@@ -26,12 +26,12 @@ build_flags = -DCONFIG_PATH=configuration.json -DDASHBOARD_PATH=dashboard.json -
 extra_scripts = scripts/preBuild.py
 
 [env:d1_mini]
-platform = espressif8266@3.0.0
+platform = espressif8266
 board = d1_mini
 framework = arduino
 monitor_speed = 115200
 monitor_filters = esp8266_exception_decoder
-lib_deps = 
+lib_deps =
 	ArduinoJson
 	https://github.com/maakbaas/esp8266-iot-framework
 	me-no-dev/ESP Async WebServer @ ^1.2.3
@@ -40,12 +40,12 @@ build_flags = -DCONFIG_PATH=configuration.json -DDASHBOARD_PATH=dashboard.json -
 extra_scripts = scripts/preBuild.py
 
 [env:d1]
-platform = espressif8266@3.0.0
+platform = espressif8266
 board = d1
 framework = arduino
 monitor_speed = 115200
 monitor_filters = esp8266_exception_decoder
-lib_deps = 
+lib_deps =
 	ArduinoJson
 	https://github.com/maakbaas/esp8266-iot-framework
 	me-no-dev/ESP Async WebServer @ ^1.2.3

--- a/src/ferraris.cpp
+++ b/src/ferraris.cpp
@@ -43,16 +43,19 @@ Ferraris::Ferraris()
   : m_state(startup)
   , m_config_rev_kWh(75)
   , m_config_debounce(80)
+  , m_config_twoway(false)
   , m_timestamp(millis())
   , m_timestampLast1(0)
   , m_timestampLast2(0)
   , m_revolutions(0)
   , m_changed(false)
+  , m_direction(+1)
   , m_average_timestamp(0)
   , m_average_revolutions(0)
 {
   uint8_t F = Ferraris::FINSTANCE++;
-  m_PIN = Ferraris::PINS[F];
+  m_PIN  = Ferraris::PINS[F];
+  m_DPIN = Ferraris::DPINS[F];
   pinMode(m_PIN, INPUT_PULLUP);
   switch (F) {
     case 0: m_handler = staticInterruptHandler0; break;
@@ -143,15 +146,26 @@ void Ferraris::IRQhandler()
   // silver -> red
   if (m_state == Ferraris::states::silver) {
     m_state = Ferraris::states::red_debounce;
-    m_revolutions++;
-    m_timestampLast2 = m_timestampLast1;
-    m_timestampLast1 = m_timestamp;
-    m_changed = true;
+    if ((!m_config_twoway) ||
+        (m_config_twoway && (digitalRead(m_DPIN) == FERRARIS_SILVER))) {
+      m_revolutions++;
+      m_direction = std::min(1, m_direction+1);
+      m_timestampLast2 = m_timestampLast1;
+      m_timestampLast1 = m_timestamp;
+      m_changed = true;
+    }
   }
 
   // red -> silver
   if (m_state == Ferraris::states::red) {
     m_state = Ferraris::states::silver_debounce;
+    if (m_config_twoway && (digitalRead(m_DPIN) == FERRARIS_SILVER)) {
+      m_revolutions--;
+      m_direction = std::max(-1, m_direction-1);
+      m_timestampLast2 = m_timestampLast1;
+      m_timestampLast1 = m_timestamp;
+      m_changed = true;
+    }
   }
 }
 
@@ -179,7 +193,7 @@ int Ferraris::get_W() const
   if (elapsedtime == 0) return 0;
   unsigned long runningtime = millis() - m_timestampLast1;          // current open cycle
   // [60 min * 60 sec * 1000 ms] * [1 kW -> 1000 W] / [time for 1kWh]
-  return 3600000000 / (std::max(elapsedtime, runningtime) * m_config_rev_kWh);
+  return m_direction * 3600000000 / (std::max(elapsedtime, runningtime) * m_config_rev_kWh);
 }
 
 // get current consumption average since last call
@@ -197,7 +211,7 @@ int Ferraris::get_W_average()
 
   // changes during last average cycle
   unsigned long elapsedT = m_timestampLast1 - m_average_timestamp;
-  unsigned long elapsedR = m_revolutions    - m_average_revolutions;
+    signed long elapsedR = m_revolutions    - m_average_revolutions;
   if ((elapsedT == 0) || (elapsedR == 0)) return 0;
 
   // update average state with last capture
@@ -214,7 +228,7 @@ float Ferraris::get_kW() const
   if (elapsedtime == 0) return 0.0f;
   unsigned long runningtime = millis() - m_timestampLast1;          // current open cycle
   // [60 min * 60 sec * 1000 ms] * [1 kW] / [time for 1kWh]
-  return 3600000.0f / (std::max(elapsedtime, runningtime) * m_config_rev_kWh);
+  return m_direction * 3600000.0f / (std::max(elapsedtime, runningtime) * m_config_rev_kWh);
 }
 
 float Ferraris::get_kWh() const
@@ -257,4 +271,14 @@ unsigned int Ferraris::get_debounce() const
 void Ferraris::set_debounce(unsigned int value)
 {
   m_config_debounce = value;
+}
+
+bool Ferraris::get_twoway() const
+{
+  return m_config_twoway;
+}
+
+void Ferraris::set_twoway(bool flag)
+{
+  m_config_twoway = flag;
 }

--- a/src/ferraris.cpp
+++ b/src/ferraris.cpp
@@ -41,11 +41,15 @@ uint8_t Ferraris::FINSTANCE = 0;
 // private constructor
 Ferraris::Ferraris()
   : m_state(startup)
+  , m_config_rev_kWh(75)
+  , m_config_debounce(80)
   , m_timestamp(millis())
+  , m_timestampLast1(0)
+  , m_timestampLast2(0)
   , m_revolutions(0)
-  , m_rev_kWh(75)
-  , m_debounce(80)
   , m_changed(false)
+  , m_average_timestamp(0)
+  , m_average_revolutions(0)
 {
   uint8_t F = Ferraris::FINSTANCE++;
   m_PIN = Ferraris::PINS[F];
@@ -104,14 +108,14 @@ bool Ferraris::loop()
   // wait for debounce time
   int timestamp = millis();
   if (m_state == Ferraris::states::silver_debounce)
-    if ((timestamp - m_timestamp) >= 4*m_debounce) {
+    if ((timestamp - m_timestamp) >= 4*m_config_debounce) {
       m_state = Ferraris::states::silver;
       detachInterrupt(digitalPinToInterrupt(m_PIN));
       attachInterrupt(digitalPinToInterrupt(m_PIN), m_handler, FERRARIS_IRQMODE_RED);
-    }  
+    }
 
   if (m_state == Ferraris::states::red_debounce)
-    if ((timestamp - m_timestamp) >= m_debounce) {
+    if ((timestamp - m_timestamp) >= m_config_debounce) {
       if (digitalRead(m_PIN) == FERRARIS_RED) {
         m_state = Ferraris::states::red;
         detachInterrupt(digitalPinToInterrupt(m_PIN));
@@ -122,7 +126,7 @@ bool Ferraris::loop()
         m_timestamp = timestamp;
         Serial.println("Missed RED->SILVER !");
       }
-    }  
+    }
 
   // return "something has changed" state
   bool retval = m_changed;
@@ -143,12 +147,12 @@ void Ferraris::IRQhandler()
     m_timestampLast2 = m_timestampLast1;
     m_timestampLast1 = m_timestamp;
     m_changed = true;
-  }  
+  }
 
   // red -> silver
   if (m_state == Ferraris::states::red) {
     m_state = Ferraris::states::silver_debounce;
-  }  
+  }
 }
 
 
@@ -168,13 +172,40 @@ bool Ferraris::get_state() const
   }
 }
 
+// get current consumption based on duration of last revolution
 int Ferraris::get_W() const
 {
   unsigned long elapsedtime = m_timestampLast1 - m_timestampLast2;  // last full cycle
   if (elapsedtime == 0) return 0;
   unsigned long runningtime = millis() - m_timestampLast1;          // current open cycle
   // [60 min * 60 sec * 1000 ms] * [1 kW -> 1000 W] / [time for 1kWh]
-  return 3600000000 / (std::max(elapsedtime, runningtime) * m_rev_kWh);  
+  return 3600000000 / (std::max(elapsedtime, runningtime) * m_config_rev_kWh);
+}
+
+// get current consumption average since last call
+int Ferraris::get_W_average()
+{
+  // check for very low consumption (less than 2 revolutions per call)
+  if (m_average_timestamp == m_timestampLast1) {
+    return get_W();
+  }
+  if (m_average_timestamp == m_timestampLast2) {
+    m_average_timestamp   = m_timestampLast1;
+    m_average_revolutions = m_revolutions;
+    return get_W();
+  }
+
+  // changes during last average cycle
+  unsigned long elapsedT = m_timestampLast1 - m_average_timestamp;
+  unsigned long elapsedR = m_revolutions    - m_average_revolutions;
+  if ((elapsedT == 0) || (elapsedR == 0)) return 0;
+
+  // update average state with last capture
+  m_average_timestamp   = m_timestampLast1;
+  m_average_revolutions = m_revolutions;
+
+  // [60 min * 60 sec * 1000 ms] * [1 kW -> 1000 W] / [time for 1kWh]
+  return 3600000000 * elapsedR / (elapsedT * m_config_rev_kWh);
 }
 
 float Ferraris::get_kW() const
@@ -183,12 +214,12 @@ float Ferraris::get_kW() const
   if (elapsedtime == 0) return 0.0f;
   unsigned long runningtime = millis() - m_timestampLast1;          // current open cycle
   // [60 min * 60 sec * 1000 ms] * [1 kW] / [time for 1kWh]
-  return 3600000.0f / (std::max(elapsedtime, runningtime) * m_rev_kWh);  
+  return 3600000.0f / (std::max(elapsedtime, runningtime) * m_config_rev_kWh);
 }
 
 float Ferraris::get_kWh() const
 {
-  return float(m_revolutions) / float(m_rev_kWh);
+  return float(m_revolutions) / float(m_config_rev_kWh);
 }
 
 
@@ -209,21 +240,21 @@ void Ferraris::set_revolutions(unsigned long value)
 
 unsigned int Ferraris::get_U_kWh() const
 {
-  return m_rev_kWh;
+  return m_config_rev_kWh;
 }
 
 void Ferraris::set_U_kWh(unsigned int value)
 {
-  m_rev_kWh = value;
+  m_config_rev_kWh = value;
   m_changed = true;
 }
 
 unsigned int Ferraris::get_debounce() const
 {
-  return m_debounce;
+  return m_config_debounce;
 }
 
 void Ferraris::set_debounce(unsigned int value)
 {
-  m_debounce = value;
+  m_config_debounce = value;
 }

--- a/src/ferraris.h
+++ b/src/ferraris.h
@@ -34,16 +34,17 @@ class Ferraris {
 
   public:
     static Ferraris& getInstance(unsigned char F);
-    
+
     void            begin();
     bool            loop();
 
     void            IRQhandler();
 
-    bool            get_state() const;  // current PIN state
-    int             get_W() const;      // current consumption in W
-    float           get_kW() const;     // current consumption in kW
+    bool            get_state() const;  // actual PIN state
+    int             get_W() const;      // actual consumption in [W]
+    float           get_kW() const;     // actual consumption in [kW]
     float           get_kWh() const;    // total reading of meter
+    int             get_W_average();    // average consumption since last call in [W]
 
     // total revolution count
     unsigned long   get_revolutions() const;
@@ -63,13 +64,17 @@ class Ferraris {
     uint8_t           m_PIN;
     void              (*m_handler)();
     Ferraris::states  m_state;
+    unsigned int      m_config_rev_kWh;   // revolutions per kWh
+    unsigned int      m_config_debounce;  // debounce time [ms]
+
     unsigned long     m_timestamp;
     unsigned long     m_timestampLast1;
     unsigned long     m_timestampLast2;
-    unsigned long     m_revolutions;
-    unsigned int      m_rev_kWh;
-    unsigned int      m_debounce;
-    bool              m_changed;    // something has changed -> give info in loop()
+    unsigned long     m_revolutions;      // total amount of revolutions
+    bool              m_changed;          // something has changed -> give info in loop()
+
+    unsigned long     m_average_timestamp;      // last average call: timestampLast2
+    unsigned long     m_average_revolutions;    // last average call: amount of revolutions
 
     static uint8_t    FINSTANCE; // used to identify instance
 };

--- a/src/ferraris.h
+++ b/src/ferraris.h
@@ -25,7 +25,8 @@ class Ferraris {
   * IR Pin Messure 6   (D7) GPIO 13    (IO13)      (D7)
   * IR Pin Messure 7   (D8) GPIO 15                (D8)
   */
-    const u_int8_t PINS[7] = {D1, D2, D3, D5, D6, D7, D8};
+    const u_int8_t PINS[7]  = {D1, D2, D3, D5, D6, D7, D8};
+    const u_int8_t DPINS[7] = {D2, D1, D5, D3, D7, D8, D7};
 
   private: // singleton pattern: prevent access to constructors
     Ferraris();
@@ -58,20 +59,27 @@ class Ferraris {
     unsigned int    get_debounce() const;
     void            set_debounce(unsigned int value);
 
+    // config: count mode, single / two way
+    bool            get_twoway() const;
+    void            set_twoway(bool flag);
+
     enum states {startup, silver_debounce, silver, red_debounce, red};
 
   private:
     uint8_t           m_PIN;
+    uint8_t           m_DPIN;
     void              (*m_handler)();
     Ferraris::states  m_state;
     unsigned int      m_config_rev_kWh;   // revolutions per kWh
     unsigned int      m_config_debounce;  // debounce time [ms]
+    bool              m_config_twoway;    // single or dual way counting
 
     unsigned long     m_timestamp;
     unsigned long     m_timestampLast1;
     unsigned long     m_timestampLast2;
     unsigned long     m_revolutions;      // total amount of revolutions
     bool              m_changed;          // something has changed -> give info in loop()
+    short int         m_direction;        // direction of last count
 
     unsigned long     m_average_timestamp;      // last average call: timestampLast2
     unsigned long     m_average_revolutions;    // last average call: amount of revolutions

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,9 @@
   The ESP firmware update can be done via "Over-The-Air".
 
   History
+  Ver. 0.98 (20230617)
+  - combine each two meters to allow backwards counting with two IR detectors on same meter
+
   Ver. 0.97 (202302xx)
   - use "Ferraris" objects to capsule code and state for each meter
   - allow 1..7 meters just by one #define
@@ -139,35 +142,42 @@ void copyConfig2Ferraris()
   Ferraris::getInstance(0).set_U_kWh      (configManager.data.meter_loops_count_1);
   Ferraris::getInstance(0).set_revolutions(configManager.data.meter_counter_reading_1 * configManager.data.meter_loops_count_1);
   Ferraris::getInstance(0).set_debounce   (configManager.data.meter_debounce_1);
+  Ferraris::getInstance(0).set_twoway     (configManager.data.meter_twoway_1);
 #if FERRARIS_NUM > 1
   Ferraris::getInstance(1).set_U_kWh      (configManager.data.meter_loops_count_2);
   Ferraris::getInstance(1).set_revolutions(configManager.data.meter_counter_reading_2 * configManager.data.meter_loops_count_2);
   Ferraris::getInstance(1).set_debounce   (configManager.data.meter_debounce_2);
+  Ferraris::getInstance(1).set_twoway     (configManager.data.meter_twoway_2);
 #endif
 #if FERRARIS_NUM > 2
   Ferraris::getInstance(2).set_U_kWh      (configManager.data.meter_loops_count_3);
   Ferraris::getInstance(2).set_revolutions(configManager.data.meter_counter_reading_3 * configManager.data.meter_loops_count_3);
   Ferraris::getInstance(2).set_debounce   (configManager.data.meter_debounce_3);
+  Ferraris::getInstance(2).set_twoway     (configManager.data.meter_twoway_3);
 #endif
 #if FERRARIS_NUM > 3
   Ferraris::getInstance(3).set_U_kWh      (configManager.data.meter_loops_count_4);
   Ferraris::getInstance(3).set_revolutions(configManager.data.meter_counter_reading_4 * configManager.data.meter_loops_count_4);
   Ferraris::getInstance(3).set_debounce   (configManager.data.meter_debounce_4);
+  Ferraris::getInstance(3).set_twoway     (configManager.data.meter_twoway_4);
 #endif
 #if FERRARIS_NUM > 4
   Ferraris::getInstance(4).set_U_kWh      (configManager.data.meter_loops_count_5);
   Ferraris::getInstance(4).set_revolutions(configManager.data.meter_counter_reading_5 * configManager.data.meter_loops_count_5);
   Ferraris::getInstance(4).set_debounce   (configManager.data.meter_debounce_5;
+  Ferraris::getInstance(4).set_twoway     (configManager.data.meter_twoway_5);
 #endif
 #if FERRARIS_NUM > 5
   Ferraris::getInstance(5).set_U_kWh      (configManager.data.meter_loops_count_6);
   Ferraris::getInstance(5).set_revolutions(configManager.data.meter_counter_reading_6 * configManager.data.meter_loops_count_6);
   Ferraris::getInstance(5).set_debounce   (configManager.data.meter_debounce_6);
+  Ferraris::getInstance(5).set_twoway     (configManager.data.meter_twoway_6);
 #endif
 #if FERRARIS_NUM > 6
   Ferraris::getInstance(6).set_U_kWh      (configManager.data.meter_loops_count_7);
   Ferraris::getInstance(6).set_revolutions(configManager.data.meter_counter_reading_7 * configManager.data.meter_loops_count_7);
   Ferraris::getInstance(6).set_debounce   (configManager.data.meter_debounce_7);
+  Ferraris::getInstance(6).set_twoway     (configManager.data.meter_twoway_7);
 #endif
 }
 
@@ -282,7 +292,7 @@ void setup() {
   timeSync.begin(TZ_Europe_Berlin);
   dash.begin(taskB.rate);
 
-  // IR-Sensor
+  // IR-Sensor initial configuration
   copyConfig2Ferraris();
   for (uint8_t F=0; F<FERRARIS_NUM; F++) {
     Ferraris::getInstance(F).begin();
@@ -293,7 +303,7 @@ void setup() {
   MQTTclient.setCallback(parseMQTTmessage);
   MQTTclient.setBufferSize(320); // TODO: maybe we can calculate this based on the largest assumed request + its parameters?
 
-  memcpy(dash.data.Version, "v.0.97", 6);
+  memcpy(dash.data.Version, "v.0.98", 6);
 
   // activate port for status LED
   pinMode(LED_BUILTIN, OUTPUT);

--- a/src/mqtt_publish.h
+++ b/src/mqtt_publish.h
@@ -1,18 +1,5 @@
 #pragma once
 
-// Infrared vars
-#define IRPIN1 D1
-#define IRPIN2 D2
-#define IRPIN3 D3
-#define IRPIN4 D5
-#define RED1 LOW
-#define SILVER1 HIGH
-#define RED2 LOW
-#define SILVER2 HIGH
-#define RED3 LOW
-#define SILVER3 HIGH
-#define RED4 LOW
-#define SILVER4 HIGH
 
 void checkMQTTconnection(void);
 void publishMQTT(void);


### PR DESCRIPTION
(optionally ) combine each two meters to detect counting direction (forward/backwards)
this may happen when you have installed solar panels and they generate more power than are consumed at that point in time

also add some more stuck WiFi handling
and debug print with NTP based time stamps

prepare average power calculation for slow logging (smoothed average over several resolutions / longer time)